### PR TITLE
rework html string-template to encode by default

### DIFF
--- a/keuzetool/src/index.js
+++ b/keuzetool/src/index.js
@@ -98,9 +98,6 @@ class Html {
   constructor(content) {
     this.content = content;
   }
-  toString() {
-    return this.content;
-  }
 }
 
 function html(strings, ...variables) {


### PR DESCRIPTION
Currently it is needed to use `renderText` for every text. This PR does this by default and knows when raw HTML (without encoding) needs to be output using the `Html` class.