### PR TITLE
change id to string

### DIFF
--- a/keuzetool/database.json
+++ b/keuzetool/database.json
@@ -1,15 +1,15 @@
 {
-  "id": 1,
+  "id": "1",
   "name": "Ziekenhuis",
   "content": "Informatie voor ziekenhuizen",
   "children": [
     {
-      "id": 1,
+      "id": "1",
       "name": "Verwijzing nodig?",
       "content": "Informatie over verwijzingen door ziekenhuizen",
       "children": [
         {
-          "id": 1,
+          "id": "1",
           "name": "Is geamputeerd been teruggegroeid?",
           "content": "Goed verhaal hier over val de huisarts niet lastig",
           "links": [
@@ -20,7 +20,7 @@
           ]
         },
         {
-          "id": 2,
+          "id": "2",
           "name": "Ben ik roodharig?",
           "content": "Oei, dan heb je vast last van ongestelde luizen",
           "links": [


### PR DESCRIPTION
ids should be strings, so that paths are nicer to look at. It also helps with the implementations regarding paths to have a single type for ids (and not numbers/strings mixed).