### PR TITLE
nicer search results

### DIFF
--- a/keuzetool/src/rendering.js
+++ b/keuzetool/src/rendering.js
@@ -154,6 +154,9 @@ function *pairs(items) {
 }
 
 function highlightIndices(text, indices) {
+  if (indices.length === 0) {
+    return text;
+  }
   const header = text.slice(0, indices[0][0]);
   return [
     header,
@@ -166,11 +169,25 @@ function highlightIndices(text, indices) {
   ].join('');
 }
 
+function filterWholeWordIndices(text, indices) {
+  const isAlphanumeric = c => /\w/.test(c);
+  return indices.filter(([start, end]) =>
+    // Beginning of word
+    !isAlphanumeric(text[start - 1]) && isAlphanumeric(text[start]) &&
+    // Ending of word
+    !isAlphanumeric(text[end + 1]) && isAlphanumeric(text[end])
+  );
+}
+
 function highlightMatches(item, matches) {
-  return matches.reduce((item, match) => ({
-    ...item,
-    [match.key]: highlightIndices(item[match.key], match.indices)
-  }), item);
+  return matches.reduce((item, match) => {
+    const text = match.value;
+    const indices = filterWholeWordIndices(text, match.indices);
+    return {
+      ...item,
+      [match.key]: highlightIndices(text, indices)
+    }
+  }, item);
 }
 
 function renderShareModal({ title, url, fullURL }) {

--- a/keuzetool/src/search.js
+++ b/keuzetool/src/search.js
@@ -58,7 +58,12 @@ function flattenNode(node) {
 }
 
 function initSearch(database) {
-  fuse = new Fuse(flattenNode(database), {
+  const documents = flattenNode(database)
+    .map((node) => ({
+      ...node,
+      content: node.content.replace(/[^A-z0-9\.,!]+/g, ' ')
+    }));
+  fuse = new Fuse(documents, {
     includeMatches: true,
     keys: ['name', 'content']
   });


### PR DESCRIPTION
The search results currently do not look that good.

Headers from the document (and other markup) are shown, instead of plain text. It has been decided we 'platslaan' the search result contents by removing all markup. I decided that it is best to also use this to search for text, so that a user won't be searching for markdown markup.

In addition, highlights were shown for spaces and individual characters. This was unwanted. It now filters the highlighted segments for only those that match a whole word. It is a bit of an ugly hack and still results in some incorrect highlights (`vooronderzoek` still matches `deze`), but we have to look into configuring fuse correctly, fix fuse to our needs or move to another library.