### PR TITLE
Animate search box open/close

### DIFF
--- a/keuzetool/scss/front-page.scss
+++ b/keuzetool/scss/front-page.scss
@@ -57,48 +57,12 @@ main.front-page {
     }
 
     form {
-      display: flex;
-      justify-content: space-between;
-      align-content: stretch;
+      margin: 0 auto;
       width: 100%;
       height: 70px;
-
-      border-radius: 35px;
-      background-color: white;
-      box-shadow: 0px 14px 38px rgba(0, 0, 0, 0.05);
-
       input {
-        flex: 1 1 auto;
-        height: 100%;
-        padding: 0px 0px 0px 1.6em;
-
-        background: transparent;
-        border: 0;
-        font-weight: 400;
-        font-size: 16px;
-        color: #4F5157;
-
-        &:focus {
-          border-top-left-radius: 35px;
-          border-bottom-left-radius: 35px;
-        }
-      }
-
-      button {
-        flex: 0 0 168px;
-        height: 100%;
-        padding: 25px 0px;
-
-        background: #0FA5FF;
-        border: 0;
-        border-radius: 35px;
-        color: white;
-        font-size: 1.2em;
-
-        @media screen and (max-width: 767px) {
-          flex: 0 0 100px;
-          font-size: 0.8em;
-        }
+        box-shadow: 0px 14px 38px rgba(0, 0, 0, 0.05);
+        border: 1px solid #EBEEF3;
       }
     }
   }

--- a/keuzetool/scss/index.scss
+++ b/keuzetool/scss/index.scss
@@ -7,3 +7,4 @@
 @import 'child-articles';
 @import 'footer';
 @import 'modals';
+@import 'search';

--- a/keuzetool/scss/modals.scss
+++ b/keuzetool/scss/modals.scss
@@ -8,6 +8,12 @@
   top: 0;
   bottom: 0;
   background: rgba(0,0,0,0.2);
+  opacity: 0;
+  transition: opacity 0.1s ease;
+
+  &.open {
+    opacity: 1;
+  }
 
   .search-modal, .share-modal {
     background-color: white;

--- a/keuzetool/scss/modals.scss
+++ b/keuzetool/scss/modals.scss
@@ -236,6 +236,7 @@
         overflow: hidden;
       }
       button {
+        flex: 0 0 auto;
         height: 48px;
         width: 48px;
         background: #0FA5FF url('./images/copy.svg');

--- a/keuzetool/scss/modals.scss
+++ b/keuzetool/scss/modals.scss
@@ -32,24 +32,8 @@
     overflow: hidden;
 
     form {
-      input {
-        display: block;
-        width: 100%;
-        height: 68px;
-        padding: 11px 50px;
-
-        font-weight: 400;
-        font-size: 16px;
-        line-height: 24px;
-        color: #7B7E85;
-        border-radius: 16px;
-        outline: none;
-        border: none;
-
-        background-image: url('./images/search.svg');
-        background-repeat: no-repeat;
-        background-position: left 22px center;
-      }
+      width: 100%;
+      height: 68px;
 
       button.close {
         display: block;

--- a/keuzetool/scss/navigation.scss
+++ b/keuzetool/scss/navigation.scss
@@ -53,21 +53,8 @@ nav {
   form {
     flex: 1 1 250px;
     input {
-      width: 100%;
-      height: 37px;
-      padding: 11px 11px 11px 40px;
-
-      background-color: white;
-      border: 1px solid #EBEEF3;
-      border-radius: 8px;
       box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05);
-      font-size: 15px;
-      font-weight: 100;
-      color: #7B7E85;
-
-      background-image: url('./images/search.svg');
-      background-repeat: no-repeat;
-      background-position: left 12px center;
+      border: 1px solid #EBEEF3;
     }
   }
 }

--- a/keuzetool/scss/search.scss
+++ b/keuzetool/scss/search.scss
@@ -1,0 +1,36 @@
+input.search {
+  width: 100%;
+  height: 100%;
+  padding: 11px 11px 11px 40px;
+
+  background-color: white;
+  border: 0px;
+  outline: none;
+  border-radius: 8px;
+  font-size: 15px;
+  font-weight: 100;
+  color: #7B7E85;
+
+  background-image: url('./images/search.svg');
+  background-repeat: no-repeat;
+  background-position: left 12px center;
+
+  &.large {
+    padding-left: 55px;
+    font-weight: 400;
+    font-size: 16px;
+    border-radius: 16px;
+    background-position: left 22px center;
+  }
+
+  &.fake {
+    position: fixed;
+    transition: all 0.1s ease;
+    border: 1px solid #EBEEF3;
+    padding-left: 55px;
+    font-weight: 400;
+    font-size: 16px;
+    border-radius: 16px;
+    background-position: left 22px center;
+  }
+}

--- a/keuzetool/scss/search.scss
+++ b/keuzetool/scss/search.scss
@@ -25,12 +25,16 @@ input.search {
 
   &.fake {
     position: fixed;
-    transition: all 0.1s ease;
+    transition: all 0.2s ease;
     border: 1px solid #EBEEF3;
-    padding-left: 55px;
-    font-weight: 400;
-    font-size: 16px;
-    border-radius: 16px;
-    background-position: left 22px center;
+
+    &.open {
+      padding-left: 55px;
+      font-weight: 400;
+      font-size: 16px;
+      border-radius: 16px;
+      background-position: left 22px center;
+      border: 0px;
+    }
   }
 }

--- a/keuzetool/src/index.js
+++ b/keuzetool/src/index.js
@@ -13,8 +13,8 @@ import {
 } from './rendering.js';
 
 import {
-  openModal,
-  closeModal
+  ShareModal,
+  closeAllModals
 } from './modals.js';
 
 let database;
@@ -81,7 +81,7 @@ function sharePage(event) {
   if ( navigator.share ) return navigator.share(event.target.dataset);
   // Otherwise show our own modal
   const fullURL = window.location.origin + window.location.pathname + event.target.dataset.url;
-  openModal(renderShareModal({...event.target.dataset, fullURL}));
+  new ShareModal(renderShareModal({...event.target.dataset, fullURL})).open();
   document.querySelector('.share-url button').addEventListener('click', () => {
     navigator.clipboard.writeText(fullURL).then(() => {
       document.querySelector('.share-url').classList.add('shared');
@@ -102,6 +102,6 @@ function setDeviceClass() {
 function attachKeyboardHandler() {
   document.addEventListener('keyup', event => {
     if ( event.key !== "Escape" ) return;
-    if ( !closeModal() ) openSearch();
+    if ( closeAllModals() == 0 ) openSearch();
   });
 }

--- a/keuzetool/src/index.js
+++ b/keuzetool/src/index.js
@@ -55,7 +55,8 @@ function preprocessNode({ path, node, parent }) {
   return node;
 }
 
-function updatePage() {
+async function updatePage() {
+  await closeAllModals();
   const path = document.location.hash
     .replace(/^[#\/]*/g, '')
     .split('/')
@@ -100,8 +101,8 @@ function setDeviceClass() {
 }
 
 function attachKeyboardHandler() {
-  document.addEventListener('keyup', event => {
+  document.addEventListener('keyup', async event => {
     if ( event.key !== "Escape" ) return;
-    if ( closeAllModals() == 0 ) openSearch();
+    if ( await closeAllModals() == 0 ) openSearch();
   });
 }

--- a/keuzetool/src/modals.js
+++ b/keuzetool/src/modals.js
@@ -2,9 +2,9 @@ const { stringifyHtml } = require('./rendering.js');
 
 const openModals = [];
 
-function closeAllModals() {
+async function closeAllModals() {
   const size = openModals.length;
-  openModals.forEach(m => m.close());
+  for (modal of openModals) await modal.close();
   return size;
 }
 
@@ -28,8 +28,10 @@ class Modal {
   }
 
   close() {
-    document.body.removeChild(this._modal);
-    openModals.splice(openModals.indexOf(this), 1);
+    if ( [...document.body.childNodes].includes(this._modal) )
+      document.body.removeChild(this._modal);
+    const position = openModals.indexOf(this);
+    if ( position > -1 ) openModals.splice(position, 1);
   }
 }
 
@@ -43,37 +45,6 @@ class SearchModal extends Modal {
     const targetPos = this._modal.querySelector('form').getBoundingClientRect();
 
     const fakeSearch = this._searchbox.cloneNode();
-    fakeSearch.style = `
-      position: fixed;
-      left: ${sourcePos.left}px;
-      top: ${sourcePos.top}px;
-      width: ${sourcePos.width}px;
-      height: ${sourcePos.height}px;
-    `;
-    document.body.appendChild(fakeSearch);
-
-    setTimeout(() => {
-      fakeSearch.classList.add('fake');
-      fakeSearch.style = `
-        left: ${targetPos.left}px;
-        top: ${targetPos.top}px;
-        width: ${targetPos.width}px;
-        height: ${targetPos.height}px;
-      `;
-    }, 1);
-
-    setTimeout(() => this._modal.classList.add('open'), 100);
-    setTimeout(() => document.body.removeChild(fakeSearch), 100);
-  }
-
-  close() {
-    if ( !this._searchbox ) return super.close();
-
-    this._modal.classList.remove('open');
-    const sourcePos = this._modal.querySelector('form').getBoundingClientRect();
-    const targetPos = this._searchbox.getBoundingClientRect();
-
-    const fakeSearch = this._searchbox.cloneNode();
     fakeSearch.classList.add('fake');
     fakeSearch.style = `
       left: ${sourcePos.left}px;
@@ -82,21 +53,60 @@ class SearchModal extends Modal {
       height: ${sourcePos.height}px;
     `;
     document.body.appendChild(fakeSearch);
+    this._searchbox.style.opacity = 0;
 
     setTimeout(() => {
-      fakeSearch.classList.remove('fake');
+      fakeSearch.classList.add('open');
       fakeSearch.style = `
-        position: fixed;
         left: ${targetPos.left}px;
         top: ${targetPos.top}px;
         width: ${targetPos.width}px;
         height: ${targetPos.height}px;
-        transition: all 0.1s ease;
       `;
     }, 1);
 
-    setTimeout(() => super.close(), 100);
-    setTimeout(() => document.body.removeChild(fakeSearch), 100);
+    setTimeout(() => {
+      this._modal.classList.add('open');
+      document.body.removeChild(fakeSearch);
+    }, 200);
+  }
+
+  close() {
+    return new Promise((resolve, reject) => {
+      if ( !this._searchbox ) return super.close();
+
+      this._modal.classList.remove('open');
+      const sourcePos = this._modal.querySelector('form').getBoundingClientRect();
+      const targetPos = this._searchbox.getBoundingClientRect();
+
+      const fakeSearch = this._searchbox.cloneNode();
+      fakeSearch.classList.add('fake');
+      fakeSearch.classList.add('open');
+      fakeSearch.style = `
+        left: ${sourcePos.left}px;
+        top: ${sourcePos.top}px;
+        width: ${sourcePos.width}px;
+        height: ${sourcePos.height}px;
+      `;
+      document.body.appendChild(fakeSearch);
+
+      setTimeout(() => {
+        fakeSearch.classList.remove('open');
+        fakeSearch.style = `
+          left: ${targetPos.left}px;
+          top: ${targetPos.top}px;
+          width: ${targetPos.width}px;
+          height: ${targetPos.height}px;
+        `;
+      }, 1);
+
+      setTimeout(() => {
+        super.close();
+        document.body.removeChild(fakeSearch);
+        this._searchbox.style.opacity = 1;
+        resolve();
+      }, 200);
+    });
   }
 }
 
@@ -107,8 +117,13 @@ class ShareModal extends Modal {
   }
 
   close() {
-    this._modal?.classList.remove('open');
-    setTimeout(() => super.close(), 200);
+    return new Promise((resolve, reject) => {
+      this._modal?.classList.remove('open');
+      setTimeout(() => {
+        super.close();
+        resolve();
+      }, 200);
+    });
   }
 }
 

--- a/keuzetool/src/modals.js
+++ b/keuzetool/src/modals.js
@@ -1,28 +1,119 @@
 const { stringifyHtml } = require('./rendering.js');
 
-function openModal(html) {
-  const modal = document.querySelector('.modal') || document.createElement('div');
-  modal.classList.add('modal');
-  modal.innerHTML = stringifyHtml(html);
-  document.body.appendChild(modal);
-  modal.addEventListener('click', event => {
-    if (event.target === modal)
-      document.body.removeChild(modal);
-  });
-  modal.querySelector('button.close')?.addEventListener('click', () =>
-    document.body.removeChild(modal));
+const openModals = [];
+
+function closeAllModals() {
+  const size = openModals.length;
+  openModals.forEach(m => m.close());
+  return size;
 }
 
-function closeModal() {
-  const modal = document.querySelector('.modal');
-  if ( modal ) {
-    document.body.removeChild(modal);
-    return true;
+class Modal {
+  constructor(html) {
+    this._modal = document.querySelector('.modal') || document.createElement('div');
+    this._modal.classList.add('modal');
+    this._modal.innerHTML = stringifyHtml(html);
   }
-  return false;
+
+  open() {
+    document.body.appendChild(this._modal);
+
+    this._modal.addEventListener('click', event => {
+      if (event.target === this._modal) this.close();
+    });
+    this._modal.querySelector('button.close')?.addEventListener('click', () => {
+      this.close();
+    });
+    openModals.push(this);
+  }
+
+  close() {
+    document.body.removeChild(this._modal);
+    openModals.splice(openModals.indexOf(this), 1);
+  }
+}
+
+class SearchModal extends Modal {
+  open() {
+    this._searchbox = document.querySelector('input.search');
+    super.open();
+    if ( !this._searchbox ) return;
+
+    const sourcePos = this._searchbox.getBoundingClientRect();
+    const targetPos = this._modal.querySelector('form').getBoundingClientRect();
+
+    const fakeSearch = this._searchbox.cloneNode();
+    fakeSearch.style = `
+      position: fixed;
+      left: ${sourcePos.left}px;
+      top: ${sourcePos.top}px;
+      width: ${sourcePos.width}px;
+      height: ${sourcePos.height}px;
+    `;
+    document.body.appendChild(fakeSearch);
+
+    setTimeout(() => {
+      fakeSearch.classList.add('fake');
+      fakeSearch.style = `
+        left: ${targetPos.left}px;
+        top: ${targetPos.top}px;
+        width: ${targetPos.width}px;
+        height: ${targetPos.height}px;
+      `;
+    }, 1);
+
+    setTimeout(() => this._modal.classList.add('open'), 100);
+    setTimeout(() => document.body.removeChild(fakeSearch), 100);
+  }
+
+  close() {
+    if ( !this._searchbox ) return super.close();
+
+    this._modal.classList.remove('open');
+    const sourcePos = this._modal.querySelector('form').getBoundingClientRect();
+    const targetPos = this._searchbox.getBoundingClientRect();
+
+    const fakeSearch = this._searchbox.cloneNode();
+    fakeSearch.classList.add('fake');
+    fakeSearch.style = `
+      left: ${sourcePos.left}px;
+      top: ${sourcePos.top}px;
+      width: ${sourcePos.width}px;
+      height: ${sourcePos.height}px;
+    `;
+    document.body.appendChild(fakeSearch);
+
+    setTimeout(() => {
+      fakeSearch.classList.remove('fake');
+      fakeSearch.style = `
+        position: fixed;
+        left: ${targetPos.left}px;
+        top: ${targetPos.top}px;
+        width: ${targetPos.width}px;
+        height: ${targetPos.height}px;
+        transition: all 0.1s ease;
+      `;
+    }, 1);
+
+    setTimeout(() => super.close(), 100);
+    setTimeout(() => document.body.removeChild(fakeSearch), 100);
+  }
+}
+
+class ShareModal extends Modal {
+  open() {
+    super.open();
+    setTimeout(() => this._modal?.classList.add('open'), 1);
+  }
+
+  close() {
+    this._modal?.classList.remove('open');
+    setTimeout(() => super.close(), 200);
+  }
 }
 
 module.exports = {
-  openModal,
-  closeModal
+  SearchModal,
+  ShareModal,
+  closeAllModals
 };

--- a/keuzetool/src/rendering.js
+++ b/keuzetool/src/rendering.js
@@ -17,8 +17,7 @@ function renderFrontPage(page) {
         <h1>${header}</h1>
         ${renderMarkdown(blurb)}
         <form id="search">
-          <input type="text" name="" value="" autocomplete="off" placeholder="Zoeken op onderwerp" />
-          <button type="submit">Zoeken</button>
+          <input class="search large" type="text" name="" value="" autocomplete="off" placeholder="Zoeken op onderwerp" />
         </form>
       </header>
       <section class="content">
@@ -43,7 +42,7 @@ function renderPage(page) {
           <li><a href="#">Artikelen</a></li>
         </ul>
         <form id="search">
-          <input type="text" name="" value="" autocomplete="off" placeholder="Zoeken op onderwerp" />
+          <input class="search" type="text" name="" value="" autocomplete="off" placeholder="Zoeken op onderwerp" />
         </form>
       </nav>
       <section class="content">
@@ -121,7 +120,7 @@ function renderSearchModal() {
   return html`
     <section class="search-modal">
       <form>
-        <input type="text" autocomplete="off" placeholder="Zoeken op onderwerp"/>
+        <input class="search large" type="text" autocomplete="off" placeholder="Zoeken op onderwerp"/>
         <button class="close">Close dialog</button>
       </form>
       <ul></ul>

--- a/keuzetool/src/search.js
+++ b/keuzetool/src/search.js
@@ -78,12 +78,9 @@ function openSearch() {
       stringifyHtml(renderSearchResults(fuse.search(event.target.value)));
   });
   newInput.addEventListener('keydown', event => {
-    if ( event.key === "Enter" ) {
-      const hoveredSearchResult = resultList.querySelector('a:hover');
-      if ( hoveredSearchResult ) return hoveredSearchResult.click();
-      const firstSearchResult = resultList.querySelector('a');
-      if ( firstSearchResult ) return firstSearchResult.click();
-    }
+    if ( event.key === "Enter" )
+      ( resultList.querySelector('a:hover') ||
+        resultList.querySelector('a') )?.click();
   });
   newInput.focus();
 }

--- a/keuzetool/src/search.js
+++ b/keuzetool/src/search.js
@@ -79,8 +79,10 @@ function openSearch(event) {
   });
   newInput.addEventListener('keydown', event => {
     if ( event.key === "Enter" ) {
-      const firstLinkInResultList = resultList.querySelector('a');
-      if ( firstLinkInResultList ) firstLinkInResultList.click();
+      const hoveredSearchResult = resultList.querySelector('a:hover');
+      if ( hoveredSearchResult ) return hoveredSearchResult.click();
+      const firstSearchResult = resultList.querySelector('a');
+      if ( firstSearchResult ) return firstSearchResult.click();
     }
   });
   newInput.focus();

--- a/keuzetool/src/search.js
+++ b/keuzetool/src/search.js
@@ -1,6 +1,6 @@
 const Fuse = require('fuse.js/dist/fuse.common');
 const {
-  openModal
+  SearchModal
 } = require('./modals.js');
 const {
   renderSearchModal,
@@ -69,8 +69,8 @@ function initSearch(database) {
   });
 }
 
-function openSearch(event) {
-  openModal(renderSearchModal());
+function openSearch() {
+  new SearchModal(renderSearchModal()).open();
   const resultList = document.querySelector('.search-modal ul');
   const newInput = document.querySelector('.search-modal input');
   newInput.addEventListener('input', event => {


### PR DESCRIPTION
What it says on the tin, plus:

When you press Enter in the search box and an item looks "selected" (you're hovering over it with your mouse) you will now go to that item instead of the first in the list.

Unfortunately I couldn't get the search open/close animation working with just CSS. So it's become quite a bit of interdependent code and styling, which is why I chose to refactor the whole modal JS and the whole search CSS. It's a bit easier to understand / maintain now, I hope.