### PR TITLE
use flexsearch instead of fuse.js

### DIFF
--- a/keuzetool/package-lock.json
+++ b/keuzetool/package-lock.json
@@ -6,11 +6,11 @@
     "": {
       "name": "keuzetool",
       "dependencies": {
-        "fuse.js": "^6.6.2",
         "marked": "^4.0.16"
       },
       "devDependencies": {
         "file-loader": "^6.2.0",
+        "flexsearch": "^0.7.21",
         "node-sass": "^7.0.1",
         "sass-loader": "^13.0.0",
         "webpack": "^5.72.1",
@@ -1908,6 +1908,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/flexsearch": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/flexsearch/-/flexsearch-0.7.21.tgz",
+      "integrity": "sha512-W7cHV7Hrwjid6lWmy0IhsWDFQboWSng25U3VVywpHOTJnnAZNPScog67G+cVpeX9f7yDD21ih0WDrMMT+JoaYg==",
+      "dev": true
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
@@ -2012,14 +2018,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
-    },
-    "node_modules/fuse.js": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/gauge": {
       "version": "3.0.2",
@@ -7186,6 +7184,12 @@
         "path-exists": "^4.0.0"
       }
     },
+    "flexsearch": {
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/flexsearch/-/flexsearch-0.7.21.tgz",
+      "integrity": "sha512-W7cHV7Hrwjid6lWmy0IhsWDFQboWSng25U3VVywpHOTJnnAZNPScog67G+cVpeX9f7yDD21ih0WDrMMT+JoaYg==",
+      "dev": true
+    },
     "follow-redirects": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.0.tgz",
@@ -7254,11 +7258,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
-    },
-    "fuse.js": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
-      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA=="
     },
     "gauge": {
       "version": "3.0.2",

--- a/keuzetool/package.json
+++ b/keuzetool/package.json
@@ -6,6 +6,7 @@
   },
   "devDependencies": {
     "file-loader": "^6.2.0",
+    "flexsearch": "^0.7.21",
     "node-sass": "^7.0.1",
     "sass-loader": "^13.0.0",
     "webpack": "^5.72.1",
@@ -13,7 +14,6 @@
     "webpack-dev-server": "^4.9.0"
   },
   "dependencies": {
-    "fuse.js": "^6.6.2",
     "marked": "^4.0.16"
   }
 }

--- a/keuzetool/src/rendering.js
+++ b/keuzetool/src/rendering.js
@@ -168,23 +168,12 @@ function highlightIndices(text, indices) {
   ].join('');
 }
 
-function filterWholeWordIndices(text, indices) {
-  const isAlphanumeric = c => /\w/.test(c);
-  return indices.filter(([start, end]) =>
-    // Beginning of word
-    !isAlphanumeric(text[start - 1]) && isAlphanumeric(text[start]) &&
-    // Ending of word
-    !isAlphanumeric(text[end + 1]) && isAlphanumeric(text[end])
-  );
-}
-
 function highlightMatches(item, matches) {
   return matches.reduce((item, match) => {
     const text = match.value;
-    const indices = filterWholeWordIndices(text, match.indices);
     return {
       ...item,
-      [match.key]: highlightIndices(text, indices)
+      [match.key]: highlightIndices(text, match.indices)
     }
   }, item);
 }

--- a/keuzetool/src/search.js
+++ b/keuzetool/src/search.js
@@ -34,23 +34,28 @@ function escapeRegExp(text) {
 function anyOfRegExp(texts) {
   return new RegExp(
     texts
-      .map(escapeRegExp)
+      .map(text =>
+          text instanceof RegExp
+          ? text.source
+          : escapeRegExp(text)
+      )
       .join('|')
     , "giu"
   );
 }
 
 const markdownRegExp = anyOfRegExp([
-  '* ',
-  '# ',
+  /^\* /,
+  /^#+ /,
   '*',
+  '**',
   '_',
   '>',
   '`'
 ]);
 
 function demarkdown(text) {
-  return text.replace(markdownRegExp, '');
+  return text.replaceAll(markdownRegExp, '');
 }
 
 let articles;
@@ -62,7 +67,7 @@ function initSearch(database) {
       article.name,
       article.blurb,
       article.content
-    ].join('\n\n'));
+    ].filter(Boolean).join('\n\n'));
     index.add(articleIndex, text);
   }
 }
@@ -77,7 +82,7 @@ function createArticleMatches(query, articles) {
     .map(article => {
       const matches = keys
         .map(key => {
-          const value = article[key];
+          const value = demarkdown(article[key]);
           const indices = [...value.matchAll(wordRegexp)]
             .map(match => [match.index, match.index + match[0].length - 1]);
           return { key, value, indices };


### PR DESCRIPTION
Replaces https://github.com/Timendus/tech-experiments/pull/17

As mentioned in https://github.com/Timendus/tech-experiments/pull/17, the search results are not of high quality. Highlighting text also began having many workarounds.

This PR attempts to solve these issues.

[Flexsearch](https://github.com/nextapps-de/flexsearch) seems to do quite well in terms of search scoring [according to its own benchmark](https://nextapps-de.github.io/flexsearch/bench/match.html). This PR uses flexsearch instead of fuse.js.

In addition, Flexsearch doesn't support returning individual matches for highlighting text. This is added manually by matching individual words from the query in the text. I tried to use the same API/structure as fuse.js, so that the highlighting logic itself could stay intact.

One change is that I now include the articles 'blurb' for searching and in the search results.