### PR TITLE
Add datadog logs

### DIFF
--- a/keuzetool/package-lock.json
+++ b/keuzetool/package-lock.json
@@ -6,6 +6,7 @@
     "": {
       "name": "keuzetool",
       "dependencies": {
+        "@datadog/browser-logs": "^4.13.0",
         "fuse.js": "^6.6.2",
         "marked": "^4.0.16"
       },
@@ -113,6 +114,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@datadog/browser-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.13.0.tgz",
+      "integrity": "sha512-MfMge7/kj1ZCUv/MSRHI+iVtjvJGLe3rtCu3EgBTArqQ5f8aYbkFzT+YuPSqEW8U1Fj0TG5JF5GiJooY4PV4Pg=="
+    },
+    "node_modules/@datadog/browser-logs": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-logs/-/browser-logs-4.13.0.tgz",
+      "integrity": "sha512-Yv5ZFKR+5kz6svERrNyi+mxTrXVSNcqXzmAGd/v0Il18Lt/DJH/WYsT792hdIhlQbkrdGubckYaiN/WWOdb/pw==",
+      "dependencies": {
+        "@datadog/browser-core": "4.13.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -5715,6 +5729,19 @@
             "has-flag": "^3.0.0"
           }
         }
+      }
+    },
+    "@datadog/browser-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-core/-/browser-core-4.13.0.tgz",
+      "integrity": "sha512-MfMge7/kj1ZCUv/MSRHI+iVtjvJGLe3rtCu3EgBTArqQ5f8aYbkFzT+YuPSqEW8U1Fj0TG5JF5GiJooY4PV4Pg=="
+    },
+    "@datadog/browser-logs": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@datadog/browser-logs/-/browser-logs-4.13.0.tgz",
+      "integrity": "sha512-Yv5ZFKR+5kz6svERrNyi+mxTrXVSNcqXzmAGd/v0Il18Lt/DJH/WYsT792hdIhlQbkrdGubckYaiN/WWOdb/pw==",
+      "requires": {
+        "@datadog/browser-core": "4.13.0"
       }
     },
     "@discoveryjs/json-ext": {

--- a/keuzetool/package.json
+++ b/keuzetool/package.json
@@ -13,6 +13,7 @@
     "webpack-dev-server": "^4.9.0"
   },
   "dependencies": {
+    "@datadog/browser-logs": "^4.13.0",
     "fuse.js": "^6.6.2",
     "marked": "^4.0.16"
   }

--- a/keuzetool/scss/article-page.scss
+++ b/keuzetool/scss/article-page.scss
@@ -88,41 +88,117 @@ main.article-page {
       }
     }
 
-    .share {
-      button {
-        height: 40px;
-        padding: 0 16px 0 48px;
-        margin: 2em 0px;
+    .button-row {
+      display: flex;
+      .share {
+        button {
+          height: 40px;
+          padding: 0 16px 0 48px;
+          margin: 2em 0px;
 
-        border: 1px solid #D0D5DD;
-        border-radius: 8px;
-        box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05);
+          border: 1px solid #D0D5DD;
+          border-radius: 8px;
+          box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05);
 
-        font-size: 14px;
-        font-weight: 500;
-        line-height: 40px;
-        background-color: white;
-        color: #5840DD;
-        cursor: pointer;
+          font-size: 14px;
+          font-weight: 500;
+          line-height: 40px;
+          background-color: white;
+          color: #5840DD;
+          cursor: pointer;
 
-        background-image: url('./images/share-desktop.svg');
-        background-position: left 15px center;
-        background-repeat: no-repeat;
+          background-image: url('./images/share-desktop.svg');
+          background-position: left 15px center;
+          background-repeat: no-repeat;
 
-        &:hover {
-          box-shadow: 1px 2px 2px rgba(16, 24, 40, 0.1);
+          &:hover {
+            box-shadow: 1px 2px 2px rgba(16, 24, 40, 0.1);
+          }
+
+          .android & {
+            background-image: url('./images/share-android.svg');
+          }
+          .ios & {
+            background-image: url('./images/share-ios.svg');
+          }
         }
 
-        .android & {
-          background-image: url('./images/share-android.svg');
-        }
-        .ios & {
-          background-image: url('./images/share-ios.svg');
+        @media screen and (max-width: 767px) {
+          text-align: center;
         }
       }
+      
+      .helped {
+        button {
+          height: 40px;
+          padding: 0 16px 0 48px;
+          margin: 2em 0px;
 
-      @media screen and (max-width: 767px) {
-        text-align: center;
+          border: 1px solid #D0D5DD;
+          border-radius: 8px;
+          box-shadow: 0px 1px 2px rgba(16, 24, 40, 0.05);
+
+          font-size: 14px;
+          font-weight: 500;
+          line-height: 40px;
+          background-color: white;
+          color: #5840DD;
+          cursor: pointer;
+
+          background-image: url('./images/share-desktop.svg');
+          background-position: left 15px center;
+          background-repeat: no-repeat;
+
+          &:hover {
+            box-shadow: 1px 2px 2px rgba(16, 24, 40, 0.1);
+          }
+
+          .android & {
+            background-image: url('./images/share-android.svg');
+          }
+          .ios & {
+            background-image: url('./images/share-ios.svg');
+          }
+        }
+
+        &.hasHelped {
+          button:before {
+            content: 'Uw reactie is gedeeld!';
+            position: relative;
+            display: block;
+            width: 150px;
+            height: 36px;
+            top: -14 - 36px;
+            left: -18px;
+
+            background: #0C1421;
+            border-radius: 4px;
+            font-weight: 400;
+            font-size: 13px;
+            line-height: 36px;
+            color: white;
+            cursor: default;
+          }
+
+          button:after {
+            content: '';
+            position: relative;
+            display: block;
+            top: -14 - 36px;
+            left: 20px;
+            width: 0px;
+            height: 0px;
+
+            border-top: 6px solid #0C1421;
+            border-left: 6px solid transparent;
+            border-right: 6px solid transparent;
+            cursor: default;
+          }
+        }
+
+        @media screen and (max-width: 767px) {
+          text-align: center;
+        }
       }
     }
 

--- a/keuzetool/src/index.js
+++ b/keuzetool/src/index.js
@@ -17,6 +17,18 @@ import {
   closeAllModals
 } from './modals.js';
 
+
+// Datadog Stats
+import { datadogLogs } from '@datadog/browser-logs'
+
+datadogLogs.init({
+  clientToken: 'pub17f8509ed78f912fb055aeaa4a5d8a39',
+  site: 'datadoghq.com',
+  service: 'starfish.keuzetool',
+  forwardErrorsToLogs: false, // We don't really care about errors
+  sampleRate: 100,
+})
+
 let database;
 run();
 
@@ -71,9 +83,12 @@ async function updatePage() {
     : renderPageNotFound()
   );
 
+  datadogLogs.logger.info('Page visit', { type: 'page.visit', name: page.name, url: document.location.hash })
+
   document.getElementById('search').addEventListener('click', openSearch);
   document.querySelector('#search input').addEventListener('focus', openSearch);
   document.getElementById('share')?.addEventListener('click', sharePage);
+  document.getElementById('helped')?.addEventListener('click', hasHelped);
   window.scrollTo(0,0);
 }
 
@@ -88,6 +103,13 @@ function sharePage(event) {
       document.querySelector('.share-url').classList.add('shared');
     });
   });
+}
+
+function hasHelped(event) {
+  event.preventDefault();
+  
+  datadogLogs.logger.info('Page has helped', { type: 'page.helped', url: document.location.hash })
+  document.querySelector('.helped').classList.add('hasHelped');
 }
 
 function urlFromPath(path) {

--- a/keuzetool/src/rendering.js
+++ b/keuzetool/src/rendering.js
@@ -59,9 +59,14 @@ function renderPage(page) {
               </p>
             ` : ''}
             ${renderMarkdown(content)}
+            <div class="button-row">
             <p class="share">
               <button id="share" data-title="${name}" data-url="${url}">Dit artikel delen</button>
             </p>
+            <p class="helped">
+              <button id="helped" data-title="${name}" data-url="${url}">Dit artikel heeft mij geholpen</button>
+            </p>
+          </div>
           </div>
           ${links && html`
             <div class="column">


### PR DESCRIPTION
I've been looking at the whole datadog implementation. There is no "native" way of using metrics. 
So for now I've decided to stick to the logs. We need to have a look at how to create some useful dashboards for this though.. Maybe through custom metrics (but perhaps some Bob magic sauce could be helpful here).

Upon visiting a page, it sends a log `Page visit` with `name` and `url` as custom properties.
Upon clicking the "this has helped me"-button, it sends a log with `Page has helped` with `name` and `url` as custom properties.

The styling may need some love (Tim may I ask you for that? 😅)

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/31534283/175503494-1d5b045c-dc21-4de9-b5d9-e4b04e73488f.png">

<img width="486" alt="image" src="https://user-images.githubusercontent.com/31534283/175503514-d5ec18ef-1526-46ab-9383-2badfd8f8f26.png">
